### PR TITLE
Removed zero initialization from concat_layer weights

### DIFF
--- a/utils/modeling.py
+++ b/utils/modeling.py
@@ -75,7 +75,6 @@ class Model_Recursive_LSTM_v2(nn.Module):
                 nn.Linear(concat_layer_sizes[i], concat_layer_sizes[i + 1], bias=True)
             )
             initialization_function_xavier(self.concat_layers[i].weight)
-            nn.init.zeros_(self.concat_layers[i].weight)
             self.concat_dropouts.append(nn.Dropout(drops[i]))
         # Output layer
         self.predict = nn.Linear(regression_layer_sizes[-1], output_size, bias=True)


### PR DESCRIPTION
The old code reset the concatenation layer weights to zeroes after initializing them with `initialization_function_xavier()`.  This PR removes this discrepancy to be in line with the weight initialization of the computation embedding and regression layers.