### PR TITLE
Added simple feedforward model variant and supporting utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,4 +185,6 @@ wandb/
 *.ipynb
 logs/log_Recursive_LSTM_v2_test_13+4+2.6.txt
 conf/*
+!conf/model/*.yaml
+!conf/model/
 batched/

--- a/README.md
+++ b/README.md
@@ -45,3 +45,11 @@ To evaluate the trained model, run the python script `evaluate_model.py` (after 
 ```bash
 python evaluate_model.py
 ```
+
+## Notes on evaluation metrics
+This repository tracks two types of Mean Absolute Percentage Error (MAPE):
+- Instance-wise MAPE: Computed during training via train_model.py. It averages the error over all (function, schedule) pairs individually. This is the metric logged to wandb, and it is the one reported in the paper.
+- Function-wise MAPE: Computed by evaluate_model.py. It first averages errors per function, then averages across all functions giving equal weight to each function, regardless of how many schedules it has.
+
+Due to the difference in weighting, the two metrics can yield different values.
+For consistency with the paper and comparison purposes, please report instance-wise MAPE.

--- a/conf/model/fcnn.yaml
+++ b/conf/model/fcnn.yaml
@@ -1,0 +1,14 @@
+name: "fcnn"
+input_size: 846 # Size of the input. Here we specify the size of the computation vector.
+max_comps: 12 # Maximum number of computations per program in the dataset. Check out utils/check_max_comps.py to verify
+comp_embed_layer_sizes:
+  - 600
+  - 350
+  - 200
+  - 180
+drops: # Dropout layers probabilities
+  - 0.050
+  - 0.050
+  - 0.050
+  - 0.050
+  - 0.050

--- a/conf/model/fcnn.yaml
+++ b/conf/model/fcnn.yaml
@@ -12,3 +12,5 @@ drops: # Dropout layers probabilities
   - 0.050
   - 0.050
   - 0.050
+mlp_layer_sizes: [512, 256, 128, 64]
+mlp_dropout: 0.20

--- a/conf/model/fcnn.yaml
+++ b/conf/model/fcnn.yaml
@@ -12,5 +12,7 @@ drops: # Dropout layers probabilities
   - 0.050
   - 0.050
   - 0.050
-mlp_layer_sizes: [512, 256, 128, 64]
+#mlp_layer_sizes: [512, 256, 128, 64]
+mlp_num_layers: 5
+mlp_width: 512
 mlp_dropout: 0.20

--- a/conf/model/recursive_lstm.yaml
+++ b/conf/model/recursive_lstm.yaml
@@ -1,0 +1,13 @@
+name: "recursive_lstm"
+input_size: 846 # Size of the input. Here we specify the size of the computation vector.
+comp_embed_layer_sizes:
+  - 600
+  - 350
+  - 200
+  - 180
+drops: # Dropout layers probabilities
+  - 0.050
+  - 0.050
+  - 0.050
+  - 0.050
+  - 0.050

--- a/config_template.yaml
+++ b/config_template.yaml
@@ -1,45 +1,33 @@
-experiment: # Name of the expirement 
-    name: "experiment_name" # This will be used to save the best model weights
-    base_path: "/absolute/path/to/the/model/code" 
+experiment: # Name of the expirement
+  name: "experiment_name" # This will be used to save the best model weights
+  base_path: "/absolute/path/to/the/model/code"
 
 data_generation:
-    train_dataset_file: "/path/to/the/training/dataset"  # training / validation set
-    valid_dataset_file: "/path/to/the/validation/dataset"
-    benchmark_dataset_file: "/path/to/the/benchmarks/dataset"
-    batch_size: 2048
-    nb_processes: 4 # Number of processes to use when loading the data in parallel
-    min_functions_per_tree_footprint: 2 # Minimum number of functions accepted in a batch. Set to 0 if you are using a small data sample
+  train_dataset_file: "/path/to/the/training/dataset" # training / validation set
+  valid_dataset_file: "/path/to/the/validation/dataset"
+  benchmark_dataset_file: "/path/to/the/benchmarks/dataset"
+  batch_size: 2048
+  nb_processes: 4 # Number of processes to use when loading the data in parallel
+  min_functions_per_tree_footprint: 2 # Minimum number of functions accepted in a batch. Set to 0 if you are using a small data sample
 
-training: 
-    log_file: "logs.txt" # Just the name
-    lr: 0.001
-    max_epochs: 1000 
-    training_gpu: "cuda:x" # GPU to train on. Example: cuda:2
-    validation_gpu: "cpu" # GPU to validate on. Usually the CPU is enough
-    continue_training: False # Continue training from saved model checkpoint
-    model_weights_path: "/path/to/model/weights" # Model weights to use for finetuning
+training:
+  log_file: "logs.txt" # Just the name
+  lr: 0.001
+  max_epochs: 1000
+  training_gpu: "cuda:x" # GPU to train on. Example: cuda:2
+  validation_gpu: "cpu" # GPU to validate on. Usually the CPU is enough
+  continue_training: False # Continue training from saved model checkpoint
+  model_weights_path: "/path/to/model/weights" # Model weights to use for finetuning
 
 testing:
-    testing_model_weights_path: "/path/to/model/weights" # Model weights to evaluate
-    gpu: "cuda:x" # GPU to validate on
+  testing_model_weights_path: "/path/to/model/weights" # Model weights to evaluate
+  gpu: "cuda:x" # GPU to validate on
 
-wandb: 
-    use_wandb: False # Track model progress using the Weights & Biases platform
-    project: "release_model" # Name of the project to add this expirement to
-    
-model: 
-    input_size: 846 # Size of the input. Here we specify the size of the computation vector.
-    comp_embed_layer_sizes: 
-        - 600
-        - 350
-        - 200
-        - 180
-    drops: # Dropout layers probabilities
-        - 0.050
-        - 0.050
-        - 0.050
-        - 0.050
-        - 0.050
+wandb:
+  use_wandb: False # Track model progress using the Weights & Biases platform
+  project: "release_model" # Name of the project to add this expirement to
 
 defaults:
+  - model: fcnn
+  - _self_
   - override hydra/job_logging: disabled

--- a/config_template.yaml
+++ b/config_template.yaml
@@ -13,6 +13,7 @@ data_generation:
 training:
   log_file: "logs.txt" # Just the name
   lr: 0.001
+  weight_decay: 0.015
   max_epochs: 1000
   training_gpu: "cuda:x" # GPU to train on. Example: cuda:2
   validation_gpu: "cpu" # GPU to validate on. Usually the CPU is enough

--- a/evaluate_model.py
+++ b/evaluate_model.py
@@ -22,6 +22,8 @@ def define_and_load_model(conf):
             max_comps=conf.model.max_comps,
             comp_embed_layer_sizes=list(conf.model.comp_embed_layer_sizes),
             drops=list(conf.model.drops),
+            mlp_layer_sizes=list(conf.model.mlp_layer_sizes),
+            mlp_dropout=conf.model.mlp_dropout,
             device=conf.testing.gpu,
         )
     # Load the trained model weights

--- a/evaluate_model.py
+++ b/evaluate_model.py
@@ -8,13 +8,22 @@ from utils.train_utils import *
 
 def define_and_load_model(conf):
     # Define the model
-    model = Model_Recursive_LSTM_v2(
-        input_size=conf.model.input_size,
-        comp_embed_layer_sizes=list(conf.model.comp_embed_layer_sizes),
-        drops=list(conf.model.drops),
-        loops_tensor_size=8,
-        device=conf.testing.gpu,
-    )
+    if conf.model.name == "recursive_lstm":
+        model = Model_Recursive_LSTM_v2(
+            input_size=conf.model.input_size,
+            comp_embed_layer_sizes=list(conf.model.comp_embed_layer_sizes),
+            drops=list(conf.model.drops),
+            loops_tensor_size=8,
+            device=conf.testing.gpu,
+        )
+    elif conf.model.name == "fcnn":
+        model = Model_FF_v1(
+            input_size=conf.model.input_size,
+            max_comps=conf.model.max_comps,
+            comp_embed_layer_sizes=list(conf.model.comp_embed_layer_sizes),
+            drops=list(conf.model.drops),
+            device=conf.testing.gpu,
+        )
     # Load the trained model weights
     model.load_state_dict(
         torch.load(

--- a/evaluate_model.py
+++ b/evaluate_model.py
@@ -22,7 +22,9 @@ def define_and_load_model(conf):
             max_comps=conf.model.max_comps,
             comp_embed_layer_sizes=list(conf.model.comp_embed_layer_sizes),
             drops=list(conf.model.drops),
-            mlp_layer_sizes=list(conf.model.mlp_layer_sizes),
+            mlp_num_layers=conf.model.mlp_num_layers,
+            mlp_width=conf.model.mlp_width,
+            #mlp_layer_sizes=list(conf.model.mlp_layer_sizes),
             mlp_dropout=conf.model.mlp_dropout,
             device=conf.testing.gpu,
         )

--- a/sweeps/fcnn.yaml
+++ b/sweeps/fcnn.yaml
@@ -7,7 +7,7 @@ command: # <-- tell it HOW to pass args
 
 method: random
 metric:
-  name: val_msle
+  name: val_mape
   goal: minimize
 
 parameters:

--- a/sweeps/fcnn.yaml
+++ b/sweeps/fcnn.yaml
@@ -6,19 +6,21 @@ command: # <-- tell it HOW to pass args
   - ${args_no_hyphens} # gives “param=value”, perfect for Hydra
 
 method: random
-count: 50
 metric:
   name: val_msle
   goal: minimize
 
 parameters:
+  model.mlp_num_layers: { values: [2, 3, 4, 5, 6, 8] }
+  model.mlp_width: { values: [128, 256, 512, 1024] }
   # ─────── model head ─────────
-  model.mlp_layer_sizes:
-    values:
-      - "[1024, 512, 256, 128, 64, 32]"
-      - "[1024, 512, 256, 128, 64]"
-      - "[512, 256, 128, 64]"
-      - "[256, 128, 64]"
+  # model.mlp_layer_sizes:
+  #   values:
+  #     - "[1024, 512, 256, 128, 64, 32]"
+  #     - "[1024, 512, 256, 128, 64]"
+  #     - "[512, 256, 128, 64]"
+  #     - "[256, 128, 64]"
+
   model.mlp_dropout:
     distribution: uniform
     min: 0.0
@@ -26,14 +28,11 @@ parameters:
 
   # ───────── optimiser ─────────
   training.lr:
-    distribution: log_uniform_values # or log_uniform
+    distribution: log_uniform_values
     min: 0.00001 # 1e-5
     max: 0.003 # 3e-3
+
   training.weight_decay:
     distribution: log_uniform_values
-    min: 0.0000001 # instead of 1e-7
+    min: 0.00000001
     max: 0.001
-
-  # shorter runs while searching
-  training.max_epochs:
-    values: [20, 30]

--- a/sweeps/fcnn.yaml
+++ b/sweeps/fcnn.yaml
@@ -1,0 +1,39 @@
+program: train_model.py # <-- tell wandb what to launch
+command: # <-- tell it HOW to pass args
+  - ${env}
+  - python
+  - ${program}
+  - ${args_no_hyphens} # gives “param=value”, perfect for Hydra
+
+method: random
+count: 50
+metric:
+  name: val_msle
+  goal: minimize
+
+parameters:
+  # ─────── model head ─────────
+  model.mlp_layer_sizes:
+    values:
+      - "[1024, 512, 256, 128, 64, 32]"
+      - "[1024, 512, 256, 128, 64]"
+      - "[512, 256, 128, 64]"
+      - "[256, 128, 64]"
+  model.mlp_dropout:
+    distribution: uniform
+    min: 0.0
+    max: 0.5
+
+  # ───────── optimiser ─────────
+  training.lr:
+    distribution: log_uniform_values # or log_uniform
+    min: 0.00001 # 1e-5
+    max: 0.003 # 3e-3
+  training.weight_decay:
+    distribution: log_uniform_values
+    min: 0.0000001 # instead of 1e-7
+    max: 0.001
+
+  # shorter runs while searching
+  training.max_epochs:
+    values: [20, 30]

--- a/train_model.py
+++ b/train_model.py
@@ -53,13 +53,22 @@ def main(conf):
     validation_device = torch.device(conf.training.validation_gpu)
     # Defining the model
     logging.info("Defining the model")
-    model = Model_Recursive_LSTM_v2(
-        input_size=conf.model.input_size,
-        comp_embed_layer_sizes=list(conf.model.comp_embed_layer_sizes),
-        drops=list(conf.model.drops),
-        loops_tensor_size=8,
-        device=train_device,
-    )
+    if conf.model.name == "recursive_lstm":
+        model = Model_Recursive_LSTM_v2(
+            input_size=conf.model.input_size,
+            comp_embed_layer_sizes=list(conf.model.comp_embed_layer_sizes),
+            drops=list(conf.model.drops),
+            loops_tensor_size=8,
+            device=train_device,
+        )
+    elif conf.model.name == "fcnn":
+        model = Model_FF_v1(
+            input_size=conf.model.input_size,
+            max_comps=conf.model.max_comps,
+            comp_embed_layer_sizes=list(conf.model.comp_embed_layer_sizes),
+            drops=list(conf.model.drops),
+            device=train_device,
+        )
     
     # Load model weights and continue training if specified  
     if conf.training.continue_training:

--- a/train_model.py
+++ b/train_model.py
@@ -67,6 +67,8 @@ def main(conf):
             max_comps=conf.model.max_comps,
             comp_embed_layer_sizes=list(conf.model.comp_embed_layer_sizes),
             drops=list(conf.model.drops),
+            mlp_layer_sizes=list(conf.model.mlp_layer_sizes),
+            mlp_dropout=conf.model.mlp_dropout,
             device=train_device,
         )
     
@@ -120,7 +122,7 @@ def main(conf):
     # Defining training params
     criterion = mape_criterion
     optimizer = torch.optim.AdamW(
-        model.parameters(), lr=conf.training.lr, weight_decay=0.15e-1
+        model.parameters(), lr=conf.training.lr, weight_decay=conf.training.weight_decay
     )
     logger = logging.getLogger()
     if conf.wandb.use_wandb:

--- a/train_model.py
+++ b/train_model.py
@@ -67,7 +67,9 @@ def main(conf):
             max_comps=conf.model.max_comps,
             comp_embed_layer_sizes=list(conf.model.comp_embed_layer_sizes),
             drops=list(conf.model.drops),
-            mlp_layer_sizes=list(conf.model.mlp_layer_sizes),
+            mlp_num_layers=conf.model.mlp_num_layers,
+            mlp_width=conf.model.mlp_width,
+            #mlp_layer_sizes=list(conf.model.mlp_layer_sizes),
             mlp_dropout=conf.model.mlp_dropout,
             device=train_device,
         )

--- a/utils/check_max_comps.py
+++ b/utils/check_max_comps.py
@@ -1,0 +1,42 @@
+import os
+import glob
+import torch
+
+# -----------------------------------------
+# Paths to scan – add/remove patterns here
+# -----------------------------------------
+PATTERNS = [
+    "batched/train/*_GPU.pt",   # training batches
+    "batched/valid/*_GPU.pt",     # validation batches
+    # If there are *_CPU.pt files, add another pattern:
+    # "batched/**/**/*_CPU.pt",
+]
+
+def main():
+    file_list = []
+    for pat in PATTERNS:
+        file_list.extend(glob.glob(pat))
+
+    if not file_list:
+        raise FileNotFoundError(
+            "No .pt files matched the patterns: {}".format(PATTERNS)
+        )
+
+    max_comps = 0
+    examined_batches = 0
+    for pt_path in sorted(file_list):
+        print(f"Scanning {pt_path} ...")
+        batches = torch.load(pt_path, map_location="cpu")
+
+        for sample, _ in batches:
+            comps_tensor_first_part = sample[1]  # index 1 holds the tensor
+            num_comps = comps_tensor_first_part.shape[1]
+            max_comps = max(max_comps, num_comps)
+            examined_batches += 1
+
+    print("\nFinished.")
+    print(f"Examined {examined_batches} batches across {len(file_list)} files.")
+    print(f"Maximum number of computations found: {max_comps}")
+
+if __name__ == "__main__":
+    main()

--- a/utils/modeling.py
+++ b/utils/modeling.py
@@ -267,6 +267,9 @@ class Model_FF_v1(nn.Module):
         max_comps,
         comp_embed_layer_sizes=[600, 350, 200, 180],
         drops=[0.225, 0.225, 0.225, 0.225],
+        *,  # <--- means "all following arguments must be specified as keyword arguments (i.e., name=value), not as positional arguments."
+        mlp_layer_sizes=None,
+        mlp_dropout=0.0,
         output_size=1,
         lstm_embedding_size=100,
         expr_embed_size=100,
@@ -308,11 +311,16 @@ class Model_FF_v1(nn.Module):
             self.comp_embedding_dropouts.append(nn.Dropout(drops[i]))
 
         # ------------------------------------------------------------------
-        # New feed‑forward regression head (5 FC layers).
+        # New feed‑forward regression head.
         # Input dim = max_comps * comp_embed_layer_sizes[-1]
         # ------------------------------------------------------------------
+        if isinstance(mlp_layer_sizes, str): # allow CLI/YAML to pass the list as a string, e.g. "[1024,512,256]"
+            mlp_layer_sizes = [int(x) for x in mlp_layer_sizes.strip(" []").split(",") if x]
+
         flattened_dim = self.max_comps * comp_emb_dim
-        mlp_layer_sizes = [flattened_dim, 512, 256, 128, 64, output_size]
+        default_layers = [512, 256, 128, 64]           # fallback if nothing passed
+        hidden = mlp_layer_sizes or default_layers     # user-defined or default
+        mlp_layer_sizes = [flattened_dim] + hidden + [output_size]
 
         for i in range(len(mlp_layer_sizes) - 1):
             self.mlp_layers.append(
@@ -322,6 +330,8 @@ class Model_FF_v1(nn.Module):
             )
             initialization_function_xavier(self.mlp_layers[i].weight)
 
+        # one shared dropout module
+        self.mlp_dropout = nn.Dropout(mlp_dropout)
 
         self.ELU = nn.ELU()
         self.LeakyReLU = nn.LeakyReLU(0.01)
@@ -443,6 +453,6 @@ class Model_FF_v1(nn.Module):
         # -------------------------------------------------------------
         x = mlp_in
         for layer in self.mlp_layers[:-1]:
-            x = self.ELU(layer(x))
+            x = self.mlp_dropout(self.ELU(layer(x)))
         out = self.LeakyReLU(self.mlp_layers[-1](x))
         return out.squeeze(-1)

--- a/utils/modeling.py
+++ b/utils/modeling.py
@@ -268,7 +268,8 @@ class Model_FF_v1(nn.Module):
         comp_embed_layer_sizes=[600, 350, 200, 180],
         drops=[0.225, 0.225, 0.225, 0.225],
         *,  # <--- means "all following arguments must be specified as keyword arguments (i.e., name=value), not as positional arguments."
-        mlp_layer_sizes=None,
+        mlp_num_layers=5,
+        mlp_width=512,
         mlp_dropout=0.0,
         output_size=1,
         lstm_embedding_size=100,
@@ -314,12 +315,13 @@ class Model_FF_v1(nn.Module):
         # New feed‑forward regression head.
         # Input dim = max_comps * comp_embed_layer_sizes[-1]
         # ------------------------------------------------------------------
-        if isinstance(mlp_layer_sizes, str): # allow CLI/YAML to pass the list as a string, e.g. "[1024,512,256]"
-            mlp_layer_sizes = [int(x) for x in mlp_layer_sizes.strip(" []").split(",") if x]
+        #if isinstance(mlp_layer_sizes, str): # allow CLI/YAML to pass the list as a string, e.g. "[1024,512,256]"
+        #    mlp_layer_sizes = [int(x) for x in mlp_layer_sizes.strip(" []").split(",") if x]
 
         flattened_dim = self.max_comps * comp_emb_dim
-        default_layers = [512, 256, 128, 64]           # fallback if nothing passed
-        hidden = mlp_layer_sizes or default_layers     # user-defined or default
+        #default_layers = [512, 256, 128, 64]           # fallback if nothing passed
+        #hidden = mlp_layer_sizes or default_layers     # user-defined or default
+        hidden = [mlp_width] * mlp_num_layers
         mlp_layer_sizes = [flattened_dim] + hidden + [output_size]
 
         for i in range(len(mlp_layer_sizes) - 1):

--- a/utils/modeling.py
+++ b/utils/modeling.py
@@ -241,3 +241,208 @@ class Model_Recursive_LSTM_v2(nn.Module):
         # We know the speedups to be predicted need to be greater or  equal to zero
         # We use the LeakyRelu to assure this while avoiding the dying ReLu problem
         return self.LeakyReLU(out[:, 0, 0])
+
+
+# -----------------------------------------------------------------------
+# Feed‑forward alternative to LOOPer’s recursive model
+# -----------------------------------------------------------------------
+# This model keeps the original computation‑vector embedding pipeline
+# (expressions → LSTM; transformation vectors → LSTM; three‑part static
+# feature vector → FC layers) but drops all subsequent LSTM/recursive
+# aggregation over the loop tree.  Instead, it flattens the resulting
+# computation embeddings (post‑order traversal, up to max_comps)
+# and feeds the concatenated vector through a 5‑layer MLP.
+# -----------------------------------------------------------------------
+
+class Model_FF_v1(nn.Module):
+    """Feed-forward variant of the LOOPer cost model (no tree recursion).
+
+    Parameters mirror those of the original model where they are still
+    relevant.  Anything related to loop/node LSTMs is omitted because
+    they are not used here.
+    """
+    def __init__(
+        self,
+        input_size,
+        max_comps,
+        comp_embed_layer_sizes=[600, 350, 200, 180],
+        drops=[0.225, 0.225, 0.225, 0.225],
+        output_size=1,
+        lstm_embedding_size=100,
+        expr_embed_size=100,
+        device="cpu",
+        num_layers=1,
+        bidirectional=True,
+    ):
+        super().__init__()
+        self.device = device
+        self.max_comps = max_comps
+        comp_emb_dim = comp_embed_layer_sizes[-1]
+
+        comp_embed_layer_sizes = [
+            input_size + lstm_embedding_size * (2 if bidirectional else 1) * num_layers + expr_embed_size
+        ] + comp_embed_layer_sizes
+
+        self.comp_embedding_layers = nn.ModuleList()
+        self.comp_embedding_dropouts = nn.ModuleList()
+        self.mlp_layers = nn.ModuleList()
+
+        # ------------------------------------------------------------------
+        # Modules reused from the original pipeline — these produce the
+        # per‑computation embedding vectors.
+        # ------------------------------------------------------------------
+        # Create the transformation encoding layers
+        self.encode_vectors = nn.Linear(
+            MAX_TAGS,
+            MAX_TAGS,
+            bias=True
+        )
+        # Create the computation embedding layers
+        for i in range(len(comp_embed_layer_sizes) - 1):
+            self.comp_embedding_layers.append(
+                nn.Linear(
+                    comp_embed_layer_sizes[i], comp_embed_layer_sizes[i + 1], bias=True
+                )
+            )
+            initialization_function_xavier(self.comp_embedding_layers[i].weight)
+            self.comp_embedding_dropouts.append(nn.Dropout(drops[i]))
+
+        # ------------------------------------------------------------------
+        # New feed‑forward regression head (5 FC layers).
+        # Input dim = max_comps * comp_embed_layer_sizes[-1]
+        # ------------------------------------------------------------------
+        flattened_dim = self.max_comps * comp_emb_dim
+        mlp_layer_sizes = [flattened_dim, 512, 256, 128, 64, output_size]
+
+        for i in range(len(mlp_layer_sizes) - 1):
+            self.mlp_layers.append(
+                nn.Linear(
+                    mlp_layer_sizes[i], mlp_layer_sizes[i+1], bias=True
+                )
+            )
+            initialization_function_xavier(self.mlp_layers[i].weight)
+
+
+        self.ELU = nn.ELU()
+        self.LeakyReLU = nn.LeakyReLU(0.01)
+
+        # LSTM to encode computations
+        self.transformation_vectors_embed = nn.LSTM(
+            MAX_TAGS,
+            lstm_embedding_size,
+            batch_first=True,
+            bidirectional=bidirectional,
+            num_layers=num_layers,
+        )
+        # LSTM to encode computation expressions
+        self.exprs_embed = nn.LSTM(
+            11,  # length of operation‑one‑hot per token
+            expr_embed_size,
+            batch_first=True,
+        )
+
+    # ------------------------------------------------------------------
+    # Utility: post‑order traversal to get computation indices
+    # ------------------------------------------------------------------
+    def post_order_indices(self, node):
+        indices = []
+        for child in node.get("child_list", []):
+            indices.extend(self.post_order_indices(child))
+        indices.extend(node.get("computations_indices", []))
+        return indices
+
+    # ------------------------------------------------------------------
+    # Forward pass
+    # ------------------------------------------------------------------
+    def forward(self, tree_tensors):
+        (
+            tree,
+            comps_tensor_first_part,
+            comps_tensor_vectors,
+            comps_tensor_third_part,
+            _,  # loops_tensor (unused)
+            functions_comps_expr_tree,
+        ) = tree_tensors
+
+        # -------------------------------------------------------------
+        # 1. Expression embeddings
+        # -------------------------------------------------------------
+        batch_size, num_comps, len_sequence, len_vector = functions_comps_expr_tree.shape
+        
+        # Expressions embedding layer
+        x = functions_comps_expr_tree.view(batch_size * num_comps, len_sequence, len_vector)
+        _, (expr_embedding, _) = self.exprs_embed(x)
+
+        expr_embedding = expr_embedding.permute(1, 0, 2).reshape(
+            batch_size * num_comps, -1
+        )
+
+        # -------------------------------------------------------------
+        # 2. Transformation‑vector embeddings
+        # -------------------------------------------------------------
+        vectors = self.encode_vectors(comps_tensor_vectors.to(self.device))
+        _, (prog_embedding, _) = self.transformation_vectors_embed(vectors)
+        prog_embedding = prog_embedding.permute(1, 0, 2).reshape(
+            batch_size * num_comps, -1
+        )
+
+        # -------------------------------------------------------------
+        # 3. Static first/third parts
+        # -------------------------------------------------------------
+        first_part = comps_tensor_first_part.to(self.device).view(batch_size * num_comps, -1)
+        third_part = comps_tensor_third_part.to(self.device).view(batch_size * num_comps, -1)
+
+        # -------------------------------------------------------------
+        # 4. Build per‑computation embedding
+        # -------------------------------------------------------------
+        # Concatinate the leftover parts from the computatuion, the vectors embedding, and the expression embedding
+        x = torch.cat(
+            (
+                first_part,
+                prog_embedding,
+                third_part,
+                expr_embedding,
+            ),
+            dim=1,
+        ).view(batch_size, num_comps, -1)
+
+        # Pass the concatinated vector through a feed forward neural network to extract the final computation embedding vector
+        for i in range(len(self.comp_embedding_layers)):
+            x = self.comp_embedding_layers[i](x)
+            x = self.comp_embedding_dropouts[i](self.ELU(x))
+        comps_embeddings = x
+        emb_dim = comps_embeddings.size(-1)
+
+        # -------------------------------------------------------------
+        # 5. Flatten computations in post‑order (pad to max_comps)
+        # -------------------------------------------------------------
+        indices = []
+        for root in tree["roots"]: # get a post-order list of computation indices
+            indices.extend(self.post_order_indices(root))
+
+        # make sure number of computations < max_comps
+        if len(indices) > self.max_comps:
+            raise RuntimeError(
+                f"Program has {len(indices)} computations, but MAX_COMPS is {self.max_comps}"
+            )
+        real_len = len(indices)
+
+        # gather embeddings for those indices (shape B × real_len × emb_dim)
+        flat = torch.index_select(comps_embeddings, 1, comps_embeddings.new_tensor(indices, dtype=torch.long))
+
+        # if we need padding, append zeros so we reach (B × max_comps × emb_dim)
+        if real_len < self.max_comps:
+            pad_size = (batch_size, self.max_comps - real_len, emb_dim)
+            flat = torch.cat([flat, flat.new_zeros(pad_size)], dim=1)
+
+        # reshape to (B, max_comps * emb_dim)
+        mlp_in = flat.reshape(batch_size, -1)
+
+        # -------------------------------------------------------------
+        # 6. MLP regression
+        # -------------------------------------------------------------
+        x = mlp_in
+        for layer in self.mlp_layers[:-1]:
+            x = self.ELU(layer(x))
+        out = self.LeakyReLU(self.mlp_layers[-1](x))
+        return out.squeeze(-1)

--- a/utils/train_utils.py
+++ b/utils/train_utils.py
@@ -135,9 +135,9 @@ def train_model(
                 if config.wandb.use_wandb:
                     wandb.log(
                         {
-                            "best_msle": best_loss,
-                            "train_msle": train_loss,
-                            "val_msle": epoch_loss,
+                            "best_mape": best_loss,
+                            "train_mape": train_loss,
+                            "val_mape": epoch_loss,
                             "epoch": epoch,
                         }
                     )


### PR DESCRIPTION
## Summary
This PR introduces:

- A simple feedforward model architecture (`Model_FF_v1`) as an explored alternative to the existing recursive model
- A `check_max_comps.py` script to compute the maximum number of computations in the dataset, used by the `Model_FF_v1` as its fixed input size
- A `model` directory inside `conf/` for switching between different model architectures via configuration
- Minor changes to `train_model.py` and `evaluate_model.py` to support dynamic model selection via `conf.yaml` or CLI
- A `sweep/` directory with a wandb sweep config used for hyperparameter tuning
- A clarification in the README explaining the difference between instance-wise and function-wise MAPE
- A renaming from `val_msle` to `val_mape` for clarity

Let me know if you'd prefer these changes split across separate PRs!