### PR TITLE
Clarify MAPE metric types in README and rename val_msle to val_mape

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,11 @@ To evaluate the trained model, run the python script `evaluate_model.py` (after 
 ```bash
 python evaluate_model.py
 ```
+
+## Notes on evaluation metrics
+This repository tracks two types of Mean Absolute Percentage Error (MAPE):
+- Instance-wise MAPE: Computed during training via train_model.py. It averages the error over all (function, schedule) pairs individually. This is the metric logged to wandb, and it is the one reported in the paper.
+- Function-wise MAPE: Computed by evaluate_model.py. It first averages errors per function, then averages across all functions giving equal weight to each function, regardless of how many schedules it has.
+
+Due to the difference in weighting, the two metrics can yield different values.
+For consistency with the paper and comparison purposes, please report instance-wise MAPE.

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ python evaluate_model.py
 
 ## Notes on evaluation metrics
 This repository tracks two types of Mean Absolute Percentage Error (MAPE):
-- Instance-wise MAPE: Computed during training via train_model.py. It averages the error over all (function, schedule) pairs individually. This is the metric logged to wandb, and it is the one reported in the paper.
-- Function-wise MAPE: Computed by evaluate_model.py. It first averages errors per function, then averages across all functions giving equal weight to each function, regardless of how many schedules it has.
+- Instance-wise MAPE: Computed during training via `train_model.py`. It averages the error over all (function, schedule) pairs individually. This is the metric logged to wandb, and it is the one reported in the paper.
+- Function-wise MAPE: Computed by `evaluate_model.py`. It first averages errors per function, then averages across all functions giving equal weight to each function, regardless of how many schedules it has.
 
 Due to the difference in weighting, the two metrics can yield different values.
 For consistency with the paper and comparison purposes, please report instance-wise MAPE.

--- a/utils/train_utils.py
+++ b/utils/train_utils.py
@@ -135,9 +135,9 @@ def train_model(
                 if config.wandb.use_wandb:
                     wandb.log(
                         {
-                            "best_msle": best_loss,
-                            "train_msle": train_loss,
-                            "val_msle": epoch_loss,
+                            "best_mape": best_loss,
+                            "train_mape": train_loss,
+                            "val_mape": epoch_loss,
                             "epoch": epoch,
                         }
                     )


### PR DESCRIPTION
This PR includes two documentation/clarity fixes:

- A clarification in the README explaining the difference between instance-wise and function-wise MAPE
- A renaming of the logged metric key from `val_msle` to `val_mape` for consistency and clarity

This follows Prof. Baghdadi's suggestion to document the metric differences and clean up old naming artifacts.